### PR TITLE
Add MLX bench infra and Muon/env controls

### DIFF
--- a/train.py
+++ b/train.py
@@ -5,18 +5,42 @@ Usage: uv run train.py
 """
 
 import gc
+import json
 import math
 import os
+import platform
+import statistics
+import subprocess
 import time
 from dataclasses import dataclass
+from functools import partial
 
 import mlx.core as mx
 import mlx.nn as nn
 from mlx.utils import tree_flatten, tree_map
-
 from prepare import MAX_SEQ_LEN, TIME_BUDGET, Tokenizer, evaluate_bpb, make_dataloader
 
 os.environ["HF_HUB_DISABLE_PROGRESS_BARS"] = "1"
+
+
+def env_int(name, default):
+    return int(os.environ.get(name, str(default)))
+
+
+def env_float(name, default):
+    return float(os.environ.get(name, str(default)))
+
+
+def env_str(name, default):
+    return os.environ.get(name, default)
+
+
+def env_betas(name, default):
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    beta1, beta2 = raw.split(",")
+    return (float(beta1), float(beta2))
 
 
 @dataclass
@@ -55,6 +79,40 @@ def create_sliding_window_mask(seq_len, window_size, dtype=mx.float32):
 
 def get_peak_memory_mb():
     return mx.get_peak_memory() / 1024 / 1024
+
+
+def get_machine_id():
+    try:
+        result = subprocess.run(
+            ["sysctl", "-n", "machdep.cpu.brand_string"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        chip = result.stdout.strip()
+        if chip:
+            return chip
+    except Exception:
+        pass
+    return platform.processor() or "unknown"
+
+
+def get_git_commit():
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        commit = result.stdout.strip()
+        if commit:
+            return commit
+    except Exception:
+        pass
+    return "unknown"
 
 
 class CausalSelfAttention(nn.Module):
@@ -97,7 +155,7 @@ class CausalSelfAttention(nn.Module):
         k = norm(self.rope(k))
 
         scale = 1.0 / math.sqrt(self.head_dim)
-        y = mx.fast.scaled_dot_product_attention(q, k, v, scale=scale, mask=mask)
+        y = mx.fast.scaled_dot_product_attention(q, k, v, scale=scale, mask=mask.astype(q.dtype))
         y = y.transpose(0, 2, 1, 3).reshape(batch_size, seq_len, -1)
         return self.c_proj(y)
 
@@ -150,17 +208,29 @@ class GPT(nn.Module):
         scale = 3**0.5 * n_embd**-0.5
 
         self.wte.weight = (mx.random.normal(self.wte.weight.shape) * 1.0).astype(mx.bfloat16)
-        self.lm_head.weight = (mx.random.normal(self.lm_head.weight.shape) * 0.001).astype(mx.bfloat16)
+        self.lm_head.weight = (mx.random.normal(self.lm_head.weight.shape) * 0.001).astype(
+            mx.bfloat16
+        )
 
         for block in self.blocks:
-            block.attn.c_q.weight = mx.random.uniform(-scale, scale, block.attn.c_q.weight.shape).astype(mx.bfloat16)
-            block.attn.c_k.weight = mx.random.uniform(-scale, scale, block.attn.c_k.weight.shape).astype(mx.bfloat16)
-            block.attn.c_v.weight = mx.random.uniform(-scale, scale, block.attn.c_v.weight.shape).astype(mx.bfloat16)
+            block.attn.c_q.weight = mx.random.uniform(
+                -scale, scale, block.attn.c_q.weight.shape
+            ).astype(mx.bfloat16)
+            block.attn.c_k.weight = mx.random.uniform(
+                -scale, scale, block.attn.c_k.weight.shape
+            ).astype(mx.bfloat16)
+            block.attn.c_v.weight = mx.random.uniform(
+                -scale, scale, block.attn.c_v.weight.shape
+            ).astype(mx.bfloat16)
             block.attn.c_proj.weight = mx.zeros_like(block.attn.c_proj.weight).astype(mx.bfloat16)
-            block.mlp.c_fc.weight = mx.random.uniform(-scale, scale, block.mlp.c_fc.weight.shape).astype(mx.bfloat16)
+            block.mlp.c_fc.weight = mx.random.uniform(
+                -scale, scale, block.mlp.c_fc.weight.shape
+            ).astype(mx.bfloat16)
             block.mlp.c_proj.weight = mx.zeros_like(block.mlp.c_proj.weight).astype(mx.bfloat16)
             if block.attn.ve_gate is not None:
-                block.attn.ve_gate.weight = mx.zeros_like(block.attn.ve_gate.weight).astype(mx.bfloat16)
+                block.attn.ve_gate.weight = mx.zeros_like(block.attn.ve_gate.weight).astype(
+                    mx.bfloat16
+                )
 
         self.resid_lambdas = mx.ones((self.config.n_layer,), dtype=mx.float32)
         self.x0_lambdas = mx.full((self.config.n_layer,), 0.1, dtype=mx.float32)
@@ -200,7 +270,7 @@ class GPT(nn.Module):
         x = norm(x)
         x0 = x
         for i, block in enumerate(self.blocks):
-            x = self.resid_lambdas[i] * x + self.x0_lambdas[i] * x0
+            x = self.resid_lambdas[i].astype(x.dtype) * x + self.x0_lambdas[i].astype(x.dtype) * x0
             ve = self.value_embeds[str(i)](idx) if str(i) in self.value_embeds else None
             x = block(x, ve, masks[i])
         x = norm(x)
@@ -221,67 +291,169 @@ class GPT(nn.Module):
         return mx.sum(ce) / denom
 
 
-class AdamW:
-    def __init__(self, model, unembedding_lr, embedding_lr, matrix_lr, weight_decay, adam_betas, scalar_lr):
-        self.param_config = {}
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003104),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323),
+]
+
+
+def muon_step_fused(
+    stacked_grads,
+    stacked_params,
+    momentum_buffer,
+    second_momentum_buffer,
+    momentum,
+    lr,
+    weight_decay,
+    beta2,
+    ns_steps,
+):
+    rows, cols = stacked_params.shape[-2:]
+    grads = stacked_grads.astype(momentum_buffer.dtype)
+    momentum_buffer = momentum * momentum_buffer + (1 - momentum) * grads
+    g = (1 - momentum) * grads + momentum * momentum_buffer
+
+    x = g.astype(mx.bfloat16)
+    x_norm = mx.linalg.norm(x.astype(mx.float32), axis=(-2, -1), keepdims=True)
+    x = x / (x_norm.astype(x.dtype) * 1.02 + 1e-6)
+    if rows > cols:
+        for a, b, c in polar_express_coeffs[:ns_steps]:
+            xt = mx.swapaxes(x, -2, -1)
+            a_mat = xt @ x
+            b_mat = b * a_mat + c * (a_mat @ a_mat)
+            x = a * x + x @ b_mat
+    else:
+        for a, b, c in polar_express_coeffs[:ns_steps]:
+            xt = mx.swapaxes(x, -2, -1)
+            a_mat = x @ xt
+            b_mat = b * a_mat + c * (a_mat @ a_mat)
+            x = a * x + b_mat @ x
+
+    g = x.astype(mx.float32)
+    red_dim = -1 if rows >= cols else -2
+    red_dim_size = cols if red_dim == -1 else rows
+    v_mean = mx.mean(g * g, axis=red_dim, keepdims=True)
+    v_norm = mx.sqrt(mx.sum(v_mean, axis=(-2, -1), keepdims=True) * red_dim_size)
+
+    second_momentum_f32 = second_momentum_buffer.astype(mx.float32)
+    second_momentum_f32 = beta2 * second_momentum_f32 + (1 - beta2) * v_mean
+    step_size = mx.rsqrt(mx.maximum(second_momentum_f32, 1e-10))
+    scaled_sq_sum = (v_mean * red_dim_size) * (step_size * step_size)
+    v_norm_new = mx.sqrt(mx.sum(scaled_sq_sum, axis=(-2, -1), keepdims=True))
+    final_scale = step_size * (v_norm / mx.maximum(v_norm_new, 1e-10))
+    g = g * final_scale
+
+    lr_scaled = lr * max(1.0, rows / cols) ** 0.5
+    params_f32 = stacked_params.astype(mx.float32)
+    mask = (g * params_f32) >= 0
+    new_params = (
+        params_f32
+        - lr_scaled * g
+        - lr_scaled * weight_decay * params_f32 * mask.astype(params_f32.dtype)
+    )
+    return (
+        new_params.astype(stacked_params.dtype),
+        momentum_buffer,
+        second_momentum_f32.astype(second_momentum_buffer.dtype),
+    )
+
+
+class MuonAdamW:
+    def __init__(
+        self,
+        model,
+        unembedding_lr,
+        embedding_lr,
+        matrix_lr,
+        weight_decay,
+        adam_betas,
+        scalar_lr,
+        use_muon=True,
+    ):
+        self.adam_config = {}
         self.adam_state = {}
+        self.muon_groups = []
+        self.muon_state = {}
 
         model_dim = model.config.n_embd
         dmodel_lr_scale = (model_dim / 768) ** -0.5
 
+        muon_groups_by_shape = {}
         flat_params = tree_flatten(model.parameters())
         for path, param in flat_params:
             if "blocks" in path and param.ndim == 2:
-                self.param_config[path] = {
-                    "lr": matrix_lr,
-                    "betas": adam_betas,
-                    "eps": 1e-10,
-                    "weight_decay": weight_decay,
-                }
+                if use_muon:
+                    muon_groups_by_shape.setdefault(param.shape, []).append(path)
+                else:
+                    # Controlled first pass: keep matrix params on the same raw
+                    # LR and weight decay as the Muon path so only the optimizer changes.
+                    self.adam_config[path] = {
+                        "lr": matrix_lr,
+                        "betas": adam_betas,
+                        "eps": 1e-10,
+                        "weight_decay": weight_decay,
+                    }
             elif "wte" in path:
-                self.param_config[path] = {
+                self.adam_config[path] = {
                     "lr": embedding_lr * dmodel_lr_scale,
                     "betas": adam_betas,
                     "eps": 1e-10,
                     "weight_decay": 0.0,
                 }
             elif "value_embeds" in path:
-                self.param_config[path] = {
+                self.adam_config[path] = {
                     "lr": embedding_lr * dmodel_lr_scale,
                     "betas": adam_betas,
                     "eps": 1e-10,
                     "weight_decay": 0.0,
                 }
             elif "lm_head" in path:
-                self.param_config[path] = {
+                self.adam_config[path] = {
                     "lr": unembedding_lr * dmodel_lr_scale,
                     "betas": adam_betas,
                     "eps": 1e-10,
                     "weight_decay": 0.0,
                 }
             elif "resid_lambdas" in path:
-                self.param_config[path] = {
+                self.adam_config[path] = {
                     "lr": scalar_lr * 0.01,
                     "betas": adam_betas,
                     "eps": 1e-10,
                     "weight_decay": 0.0,
                 }
             elif "x0_lambdas" in path:
-                self.param_config[path] = {
+                self.adam_config[path] = {
                     "lr": scalar_lr,
                     "betas": (0.96, 0.95),
                     "eps": 1e-10,
                     "weight_decay": 0.0,
                 }
             else:
-                self.param_config[path] = {
+                self.adam_config[path] = {
                     "lr": unembedding_lr * dmodel_lr_scale,
                     "betas": adam_betas,
                     "eps": 1e-10,
                     "weight_decay": 0.0,
                 }
 
-        self.initial_lrs = {path: config["lr"] for path, config in self.param_config.items()}
+        for shape in sorted(muon_groups_by_shape):
+            paths = muon_groups_by_shape[shape]
+            self.muon_groups.append(
+                {
+                    "paths": paths,
+                    "lr": matrix_lr,
+                    "initial_lr": matrix_lr,
+                    "momentum": 0.95,
+                    "ns_steps": MUON_NS_STEPS,
+                    "beta2": MUON_BETA2,
+                    "weight_decay": weight_decay,
+                }
+            )
+
+        self.adam_initial_lrs = {path: config["lr"] for path, config in self.adam_config.items()}
 
     def _set_path_value(self, model, path, value):
         parts = path.split(".")
@@ -299,7 +471,7 @@ class AdamW:
         else:
             setattr(obj, last, value)
 
-    def _step(self, path, grad, param, config):
+    def _adamw_step(self, path, grad, param, config):
         grad_f32 = grad.astype(mx.float32)
         param_f32 = param.astype(mx.float32)
         lr = config["lr"]
@@ -328,26 +500,73 @@ class AdamW:
         param_f32 = param_f32 - step_size * (state["m"] / denom)
         return param_f32.astype(param.dtype)
 
+    def _muon_step(self, model, group, flat_grads, flat_params):
+        paths = group["paths"]
+        if not all(path in flat_grads for path in paths):
+            return
+
+        stacked_grads = mx.stack([flat_grads[path] for path in paths])
+        stacked_params = mx.stack([flat_params[path] for path in paths])
+        state_key = tuple(paths)
+        if state_key not in self.muon_state:
+            num_params, rows, cols = stacked_params.shape
+            state_shape = (num_params, rows, 1) if rows >= cols else (num_params, 1, cols)
+            self.muon_state[state_key] = {
+                "momentum_buffer": mx.zeros_like(stacked_params),
+                "second_momentum_buffer": mx.zeros(state_shape, dtype=stacked_params.dtype),
+            }
+
+        state = self.muon_state[state_key]
+        new_params, state["momentum_buffer"], state["second_momentum_buffer"] = muon_step_fused(
+            stacked_grads,
+            stacked_params,
+            state["momentum_buffer"],
+            state["second_momentum_buffer"],
+            momentum=group["momentum"],
+            lr=group["lr"],
+            weight_decay=group["weight_decay"],
+            beta2=group["beta2"],
+            ns_steps=group["ns_steps"],
+        )
+        for idx, path in enumerate(paths):
+            self._set_path_value(model, path, new_params[idx])
+
     def update(self, model, grads):
         flat_grads = dict(tree_flatten(grads))
         flat_params = dict(tree_flatten(model.parameters()))
         for path, grad in flat_grads.items():
-            if path not in self.param_config:
+            if path not in self.adam_config:
                 continue
-            config = self.param_config[path]
+            config = self.adam_config[path]
             param = flat_params[path]
-            new_param = self._step(path, grad, param, config)
+            new_param = self._adamw_step(path, grad, param, config)
             self._set_path_value(model, path, new_param)
+        for group in self.muon_groups:
+            self._muon_step(model, group, flat_grads, flat_params)
 
     def set_lr_multiplier(self, multiplier):
-        for path, config in self.param_config.items():
-            config["lr"] = self.initial_lrs[path] * multiplier
+        for path, config in self.adam_config.items():
+            config["lr"] = self.adam_initial_lrs[path] * multiplier
+        for group in self.muon_groups:
+            group["lr"] = group["initial_lr"] * multiplier
+
+    def set_muon_momentum(self, momentum):
+        for group in self.muon_groups:
+            group["momentum"] = momentum
+
+    def set_muon_weight_decay(self, weight_decay):
+        for group in self.muon_groups:
+            group["weight_decay"] = weight_decay
 
     @property
     def state(self):
         arrays = []
         for state in self.adam_state.values():
             arrays.extend([state["m"], state["v"]])
+        for group in self.muon_groups:
+            state = self.muon_state.get(tuple(group["paths"]))
+            if state is not None:
+                arrays.extend([state["momentum_buffer"], state["second_momentum_buffer"]])
         return arrays
 
 
@@ -356,27 +575,32 @@ class AdamW:
 # ---------------------------------------------------------------------------
 
 # Model architecture
-ASPECT_RATIO = 64
-HEAD_DIM = 128
-WINDOW_PATTERN = "SSSL"
+ASPECT_RATIO = env_int("AUTORESEARCH_ASPECT_RATIO", 64)
+HEAD_DIM = env_int("AUTORESEARCH_HEAD_DIM", 128)
+WINDOW_PATTERN = env_str("AUTORESEARCH_WINDOW_PATTERN", "L")
 
-# v0.1: AdamW only. Muon port is future work.
-TOTAL_BATCH_SIZE = 2**16
-EMBEDDING_LR = 0.6
-UNEMBEDDING_LR = 0.004
-MATRIX_LR = 0.04
-SCALAR_LR = 0.5
-WEIGHT_DECAY = 0.2
-ADAM_BETAS = (0.8, 0.95)
-WARMUP_RATIO = 0.0
-WARMDOWN_RATIO = 0.5
-FINAL_LR_FRAC = 0.0
+TOTAL_BATCH_SIZE = env_int("AUTORESEARCH_TOTAL_BATCH_SIZE", 2**16)
+EMBEDDING_LR = env_float("AUTORESEARCH_EMBEDDING_LR", 0.6)
+UNEMBEDDING_LR = env_float("AUTORESEARCH_UNEMBEDDING_LR", 0.004)
+MATRIX_LR = env_float("AUTORESEARCH_MATRIX_LR", 0.04)
+MUON_NS_STEPS = env_int("AUTORESEARCH_MUON_NS_STEPS", 5)
+MUON_BETA2 = env_float("AUTORESEARCH_MUON_BETA2", 0.95)
+SCALAR_LR = env_float("AUTORESEARCH_SCALAR_LR", 0.5)
+WEIGHT_DECAY = env_float("AUTORESEARCH_WEIGHT_DECAY", 0.2)
+ADAM_BETAS = env_betas("AUTORESEARCH_ADAM_BETAS", (0.8, 0.95))
+WARMUP_RATIO = env_float("AUTORESEARCH_WARMUP_RATIO", 0.0)
+WARMDOWN_RATIO = env_float("AUTORESEARCH_WARMDOWN_RATIO", 0.5)
+FINAL_LR_FRAC = env_float("AUTORESEARCH_FINAL_LR_FRAC", 0.0)
+MOMENTUM_SCHEDULE = env_str("AUTORESEARCH_MOMENTUM_SCHEDULE", "baseline")
+WEIGHT_DECAY_SCHEDULE = env_str("AUTORESEARCH_WEIGHT_DECAY_SCHEDULE", "linear")
 
 # Model size
-DEPTH = 4
-DEVICE_BATCH_SIZE = 16
-FINAL_EVAL_BATCH_SIZE = 256
-STARTUP_EXCLUDE_STEPS = 1
+DEPTH = env_int("AUTORESEARCH_DEPTH", 4)
+DEVICE_BATCH_SIZE = env_int("AUTORESEARCH_DEVICE_BATCH_SIZE", 16)
+FINAL_EVAL_BATCH_SIZE = env_int("AUTORESEARCH_FINAL_EVAL_BATCH_SIZE", 256)
+STARTUP_EXCLUDE_STEPS = env_int("AUTORESEARCH_STARTUP_EXCLUDE_STEPS", 1)
+SEED = env_int("AUTORESEARCH_SEED", 42)
+USE_MUON = env_str("AUTORESEARCH_OPTIMIZER", "muon").lower() == "muon"
 
 
 def get_lr_multiplier(progress):
@@ -388,8 +612,29 @@ def get_lr_multiplier(progress):
     return cooldown * 1.0 + (1 - cooldown) * FINAL_LR_FRAC
 
 
+def get_muon_momentum(step):
+    if MOMENTUM_SCHEDULE == "constant_095":
+        return 0.95
+    if MOMENTUM_SCHEDULE == "flat":
+        frac = min(step / 600, 1)
+        return (1 - frac) * 0.90 + frac * 0.95
+    if MOMENTUM_SCHEDULE == "fast_ramp":
+        frac = min(step / 150, 1)
+        return (1 - frac) * 0.85 + frac * 0.95
+    frac = min(step / 300, 1)
+    return (1 - frac) * 0.85 + frac * 0.95
+
+
+def get_weight_decay(progress):
+    if WEIGHT_DECAY_SCHEDULE == "constant":
+        return WEIGHT_DECAY
+    if WEIGHT_DECAY_SCHEDULE == "slow_linear":
+        return WEIGHT_DECAY * (1 - 0.5 * progress)
+    return WEIGHT_DECAY * (1 - progress)
+
+
 t_start = time.time()
-mx.random.seed(42)
+mx.random.seed(SEED)
 
 tokenizer = Tokenizer.from_directory()
 vocab_size = tokenizer.get_vocab_size()
@@ -412,13 +657,16 @@ config = GPTConfig(
 model = GPT(config)
 model.init_weights()
 mx.eval(model.parameters())
+# Materialize the fixed training masks before tracing so compile never mutates the cache.
+model._get_masks(MAX_SEQ_LEN)
+mx.eval(*tuple(model._mask_cache.values()))
 num_params = sum(param.size for _, param in tree_flatten(model.parameters()))
 
 tokens_per_fwdbwd = DEVICE_BATCH_SIZE * MAX_SEQ_LEN
 assert TOTAL_BATCH_SIZE % tokens_per_fwdbwd == 0
 grad_accum_steps = TOTAL_BATCH_SIZE // tokens_per_fwdbwd
 
-optimizer = AdamW(
+optimizer = MuonAdamW(
     model,
     unembedding_lr=UNEMBEDDING_LR,
     embedding_lr=EMBEDDING_LR,
@@ -426,15 +674,25 @@ optimizer = AdamW(
     weight_decay=WEIGHT_DECAY,
     adam_betas=ADAM_BETAS,
     scalar_lr=SCALAR_LR,
+    use_muon=USE_MUON,
 )
 
-loss_grad_fn = nn.value_and_grad(model, lambda model, inputs, targets: model(inputs, targets=targets))
+_loss_grad_fn = nn.value_and_grad(model, lambda inputs, targets: model(inputs, targets=targets))
+compiled_state = [model.state]
+
+
+@partial(mx.compile, inputs=compiled_state, outputs=compiled_state)
+def loss_grad_fn(inputs, targets):
+    return _loss_grad_fn(inputs, targets)
+
 
 print(f"Time budget: {TIME_BUDGET}s")
 print(f"Gradient accumulation steps: {grad_accum_steps}")
 
 smooth_train_loss = 0.0
 total_training_time = 0.0
+step_times = []
+step_toksec = []
 step = 0
 t_compiled = None
 
@@ -444,11 +702,11 @@ while True:
     train_loss = None
 
     for _ in range(grad_accum_steps):
-        loss, grads = loss_grad_fn(model, x, y)
+        loss, grads = loss_grad_fn(x, y)
         mx.eval(loss, grads)
         if t_compiled is None:
             t_compiled = time.time()
-            print(f"Model compiled in {t_compiled - t_data:.1f}s")
+            print(f"Startup finished in {t_compiled - t_data:.1f}s")
         train_loss = loss
         if accum_grads is None:
             accum_grads = grads
@@ -462,6 +720,8 @@ while True:
     progress = min(total_training_time / TIME_BUDGET, 1.0)
     lrm = get_lr_multiplier(progress)
     optimizer.set_lr_multiplier(lrm)
+    optimizer.set_muon_momentum(get_muon_momentum(step))
+    optimizer.set_muon_weight_decay(get_weight_decay(progress))
     optimizer.update(model, accum_grads)
     mx.eval(model.parameters(), *optimizer.state)
 
@@ -471,19 +731,21 @@ while True:
         raise SystemExit(1)
 
     dt = time.time() - t0
+    tok_per_sec = int(TOTAL_BATCH_SIZE / dt) if dt > 0 else 0
     if step >= STARTUP_EXCLUDE_STEPS:
         total_training_time += dt
+        step_times.append(dt)
+        step_toksec.append(tok_per_sec)
 
     ema_beta = 0.9
     smooth_train_loss = ema_beta * smooth_train_loss + (1 - ema_beta) * train_loss_f
     debiased_smooth_loss = smooth_train_loss / (1 - ema_beta ** (step + 1))
     pct_done = 100 * progress
-    tok_per_sec = int(TOTAL_BATCH_SIZE / dt) if dt > 0 else 0
     remaining = max(0.0, TIME_BUDGET - total_training_time)
 
     print(
         f"\rstep {step:05d} ({pct_done:.1f}%) | loss: {debiased_smooth_loss:.6f} | "
-        f"lrm: {lrm:.2f} | dt: {dt*1000:.0f}ms | tok/sec: {tok_per_sec:,} | "
+        f"lrm: {lrm:.2f} | dt: {dt * 1000:.0f}ms | tok/sec: {tok_per_sec:,} | "
         f"epoch: {epoch} | remaining: {remaining:.0f}s    ",
         end="",
         flush=True,
@@ -504,7 +766,8 @@ print()
 t_train = time.time()
 print(f"Training completed in {t_train - t_compiled:.1f}s")
 
-total_tokens = step * TOTAL_BATCH_SIZE
+timed_steps = max(step - STARTUP_EXCLUDE_STEPS, 0)
+total_tokens = timed_steps * TOTAL_BATCH_SIZE
 print("Starting final eval...")
 print(f"Final eval batch size: {FINAL_EVAL_BATCH_SIZE}")
 val_bpb = evaluate_bpb(model, tokenizer, FINAL_EVAL_BATCH_SIZE)
@@ -513,6 +776,50 @@ print(f"Final eval completed in {t_eval - t_train:.1f}s")
 
 steady_state_mfu = 0.0
 peak_vram_mb = get_peak_memory_mb()
+data_load_seconds = round(t_data - t_start, 1)
+compile_seconds = round(t_compiled - t_data, 1) if t_compiled is not None else 0.0
+avg_toksec = round(statistics.mean(step_toksec)) if step_toksec else 0
+median_toksec = round(statistics.median(step_toksec)) if step_toksec else 0
+avg_step_ms = round(statistics.mean(step_times) * 1000, 1) if step_times else 0.0
+median_step_ms = round(statistics.median(step_times) * 1000, 1) if step_times else 0.0
+optimizer_name = "muon" if USE_MUON else "adamw"
+machine_id = get_machine_id()
+record = {
+    "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S"),
+    "commit": get_git_commit(),
+    "seed": SEED,
+    "optimizer": optimizer_name,
+    "machine": machine_id,
+    "mlx_version": mx.__version__,
+    "depth": DEPTH,
+    "aspect_ratio": ASPECT_RATIO,
+    "head_dim": HEAD_DIM,
+    "window_pattern": WINDOW_PATTERN,
+    "num_params_M": round(num_params / 1e6, 1),
+    "matrix_lr": MATRIX_LR,
+    "effective_matrix_lr": MATRIX_LR,
+    "weight_decay": WEIGHT_DECAY,
+    "weight_decay_schedule": WEIGHT_DECAY_SCHEDULE,
+    "adam_betas": list(ADAM_BETAS),
+    "momentum_schedule": MOMENTUM_SCHEDULE,
+    "total_batch_size": TOTAL_BATCH_SIZE,
+    "dmodel_lr_scale": round((model_dim / 768) ** -0.5, 6),
+    "matrix_lr_uses_dmodel_scale": False,
+    "val_bpb": round(val_bpb, 6),
+    "num_steps": step,
+    "timed_steps": timed_steps,
+    "total_tokens_M": round(total_tokens / 1e6, 1),
+    "data_load_seconds": data_load_seconds,
+    "compile_seconds": compile_seconds,
+    "training_seconds": round(total_training_time, 1),
+    "total_seconds": round(t_eval - t_start, 1),
+    "peak_vram_mb": round(peak_vram_mb, 1),
+    "avg_tok_sec": avg_toksec,
+    "median_tok_sec": median_toksec,
+    "avg_step_ms": avg_step_ms,
+    "median_step_ms": median_step_ms,
+}
+jsonl_path = os.environ.get("AUTORESEARCH_BENCH_LOG", "/tmp/autoresearch_bench.jsonl")
 
 print("---")
 print(f"val_bpb:          {val_bpb:.6f}")
@@ -522,5 +829,21 @@ print(f"peak_vram_mb:     {peak_vram_mb:.1f}")
 print(f"mfu_percent:      {steady_state_mfu:.2f}")
 print(f"total_tokens_M:   {total_tokens / 1e6:.1f}")
 print(f"num_steps:        {step}")
+print(f"timed_steps:      {timed_steps}")
 print(f"num_params_M:     {num_params / 1e6:.1f}")
 print(f"depth:            {DEPTH}")
+print(f"seed:             {SEED}")
+print(f"optimizer:        {optimizer_name}")
+print(f"machine:          {machine_id}")
+print(f"data_load_sec:    {data_load_seconds}")
+print(f"compile_sec:      {compile_seconds}")
+print(f"avg_tok_sec:      {avg_toksec}")
+print(f"median_tok_sec:   {median_toksec}")
+print(f"avg_step_ms:      {avg_step_ms}")
+print(f"median_step_ms:   {median_step_ms}")
+
+with open(jsonl_path, "a", encoding="utf-8") as f:
+    f.write(json.dumps(record) + "\n")
+
+print(f"Result appended to {jsonl_path}")
+print("JSON:" + json.dumps(record))


### PR DESCRIPTION
## What This PR Does
- adds the MLX benchmark/control scaffolding needed to evaluate architecture changes cleanly
- adds Muon optimizer routing plus env-driven tuning and telemetry in `train.py`
- normalizes token accounting for reproducible comparisons

## Why This Is Separate
The architecture proposal depends on this infra, but it is intentionally split into a stacked follow-up PR so this layer can be reviewed on its own.

## Not In This PR
- SwiGLU + short-conv hybrid blocks
- matched 3-seed E3 evidence
- E7 / depth-scaling / kernel-size exploration

## Review Focus
- correctness of the optimizer/control/telemetry changes in `train.py`
- whether this is the right base for follow-on architecture experiments
