### PR TITLE
fix: OOM on 24GB Macs + bf16 upcast bug + NaN loss guard

### DIFF
--- a/train.py
+++ b/train.py
@@ -39,13 +39,13 @@ def has_ve(layer_idx, n_layer):
     return layer_idx % 2 == (n_layer - 1) % 2
 
 
-def create_additive_causal_mask(seq_len, dtype=mx.float32):
+def create_additive_causal_mask(seq_len, dtype=mx.bfloat16):
     indices = mx.arange(seq_len)
     blocked = indices[None, :] > indices[:, None]
     return mx.where(blocked, mx.array(float("-inf"), dtype=dtype), mx.array(0.0, dtype=dtype))
 
 
-def create_sliding_window_mask(seq_len, window_size, dtype=mx.float32):
+def create_sliding_window_mask(seq_len, window_size, dtype=mx.bfloat16):
     indices = mx.arange(seq_len)
     causal = indices[None, :] > indices[:, None]
     too_far = (indices[:, None] - indices[None, :]) >= window_size

--- a/train.py
+++ b/train.py
@@ -57,6 +57,36 @@ def get_peak_memory_mb():
     return mx.get_peak_memory() / 1024 / 1024
 
 
+def get_safe_eval_batch_size(default=256, min_batch=4):
+    """Cap eval batch size based on available Metal memory to prevent OOM.
+
+    On 24GB Macs the default batch_size=256 triggers a Metal allocation error
+    because the eval pass requires a single buffer larger than the maximum
+    allowed (~14GB).  We detect total system RAM and scale down accordingly.
+    """
+    import subprocess
+    min_batch = min(min_batch, default)
+    try:
+        result = subprocess.run(
+            ["sysctl", "-n", "hw.memsize"],
+            capture_output=True, text=True, timeout=5, check=True,
+        )
+        total_ram_gb = int(result.stdout.strip()) / (1024 ** 3)
+    except Exception:
+        total_ram_gb = 16  # conservative fallback
+
+    # Metal's max single-buffer limit is ~75% of system RAM. The eval pass at
+    # batch_size=256 with seq_len=2048 allocates ~16GB in a single buffer,
+    # which exceeds the ~14GB limit on a 24GB Mac (reported in issue #2).
+    # We need ~20GB usable Metal headroom for the full batch_size=256.
+    usable_gb = max(total_ram_gb - 10, 2)
+    safe_batch = int(default * (usable_gb / 20))
+    safe_batch = max(min_batch, min(safe_batch, default))
+    # Round down to nearest power of 2 for alignment
+    safe_batch = 2 ** int(math.log2(safe_batch)) if safe_batch >= 1 else min_batch
+    return safe_batch
+
+
 class CausalSelfAttention(nn.Module):
     def __init__(self, config, layer_idx):
         super().__init__()
@@ -200,7 +230,7 @@ class GPT(nn.Module):
         x = norm(x)
         x0 = x
         for i, block in enumerate(self.blocks):
-            x = self.resid_lambdas[i] * x + self.x0_lambdas[i] * x0
+            x = self.resid_lambdas[i].astype(x.dtype) * x + self.x0_lambdas[i].astype(x.dtype) * x0
             ve = self.value_embeds[str(i)](idx) if str(i) in self.value_embeds else None
             x = block(x, ve, masks[i])
         x = norm(x)
@@ -375,7 +405,7 @@ FINAL_LR_FRAC = 0.0
 # Model size
 DEPTH = 4
 DEVICE_BATCH_SIZE = 16
-FINAL_EVAL_BATCH_SIZE = 256
+FINAL_EVAL_BATCH_SIZE = get_safe_eval_batch_size(default=256)
 STARTUP_EXCLUDE_STEPS = 1
 
 
@@ -466,7 +496,7 @@ while True:
     mx.eval(model.parameters(), *optimizer.state)
 
     train_loss_f = float(train_loss.item())
-    if train_loss_f > 100:
+    if not math.isfinite(train_loss_f) or train_loss_f > 100:
         print("FAIL")
         raise SystemExit(1)
 


### PR DESCRIPTION
## Summary

Fixes three open issues with minimal changes to `train.py`:

- **Fixes #2** (Out of Metal memory on MacBook Air 24GB) — `FINAL_EVAL_BATCH_SIZE=256` triggers a Metal allocation error (`Attempting to allocate 17GB > max 14GB`) on machines with ≤24GB RAM. Added `get_safe_eval_batch_size()` which detects system RAM via `sysctl` and scales the eval batch down automatically (e.g. 128 on 24GB, 64 on 16GB, full 256 on 32GB+).

- **Fixes #7** (Will it work on MacBook Air M4 24GB?) — Yes, with this fix. The auto-scaling prevents the OOM that previously blocked 24GB machines.

- **Fixes #3** (bf16→fp32 upcast in residual mix) — `resid_lambdas` and `x0_lambdas` are `float32` scalars that silently promoted the `bfloat16` hidden state to `float32` on every layer via `float32 * bfloat16 → float32`. Now casts scalars to `x.dtype` before multiply, keeping the residual stream in `bfloat16` throughout. Also updated attention mask default dtype from `float32` to `bfloat16` to match, since MLX's `scaled_dot_product_attention` requires mask dtype to promote to output dtype.

- **Bonus**: Changed `train_loss_f > 100` to `not math.isfinite(train_loss_f) or train_loss_f > 100` to catch NaN and ±inf losses (matching original Karpathy repo behavior).

## Eval batch size scaling

| System RAM | Eval Batch Size |
|-----------|----------------|
| 8 GB | 16 |
| 16 GB | 64 |
| 24 GB | 128 |
| 32 GB+ | 256 |

## Test results (M3 16GB)

Full training + eval completed successfully on a **16GB M3 Mac** (the tightest memory target):

```
val_bpb:          2.243175
training_seconds: 303.2
total_seconds:    340.9
peak_vram_mb:     8536.2
total_tokens_M:   5.7
num_steps:        87
num_params_M:     11.5
depth:            4
```

- Eval batch auto-capped to **64** (down from 256) — no OOM
- Training loss decreased steadily from 9.01 to 6.38
- All bf16 dtype checks passed — activations stay in bfloat16, no silent upcast
- NaN/inf/loss>100 guard catches all degenerate float values

## Test plan

- [x] Verify on 16GB Mac (M3) that training + eval completes without OOM
- [x] Verify eval batch size is correctly capped (64 on 16GB)
- [x] Confirm bf16 fix keeps activations in bfloat16 (no silent promotion)
- [x] Confirm attention masks use bfloat16 dtype (compatible with sdpa)
- [x] Confirm NaN/inf loss triggers early exit with "FAIL"
- [x] Verify training loss decreases normally (no accuracy degradation)
- [ ] Verify on 24GB Mac that eval batch is 128 (awaiting hardware)
- [ ] Verify on 32GB+ Mac that eval batch remains 256 (awaiting hardware)