### PR TITLE
Fix final-eval OOM (#2) and bf16 residual-stream upcast (#3)

### DIFF
--- a/prepare.py
+++ b/prepare.py
@@ -331,14 +331,28 @@ def evaluate_bpb(model, tokenizer, batch_size):
     total_nats = 0.0
     total_bytes = 0
 
+    # A single forward pass materializes a (rows, MAX_SEQ_LEN, VOCAB_SIZE)
+    # float32 logits tensor. At the defaults (256 x 2048 x 8192) that is 16 GiB
+    # in one buffer, which exceeds the Metal max buffer size on 24GB Macs and
+    # OOMs the final eval (issue #2). Cap the rows per forward so no single
+    # logits tensor exceeds the budget below; BPB is a plain sum over tokens,
+    # so splitting the batch is numerically exact regardless of batch_size.
+    logits_budget_bytes = 2 * 1024**3
+    bytes_per_row = MAX_SEQ_LEN * VOCAB_SIZE * 4
+    micro_batch = max(1, min(batch_size, logits_budget_bytes // bytes_per_row))
+
     for _ in range(steps):
         x, y, _ = next(val_loader)
-        loss_flat = model(x, y, reduction="none").reshape(-1)
-        y_flat = y.reshape(-1)
-        nbytes = mx.take(token_bytes, y_flat, axis=0)
-        mask = nbytes > 0
-        total_nats += mx.sum(loss_flat * mask).item()
-        total_bytes += int(mx.sum(nbytes).item())
+        for start in range(0, x.shape[0], micro_batch):
+            xb = x[start:start + micro_batch]
+            yb = y[start:start + micro_batch]
+            loss_flat = model(xb, yb, reduction="none").reshape(-1)
+            y_flat = yb.reshape(-1)
+            nbytes = mx.take(token_bytes, y_flat, axis=0)
+            mask = nbytes > 0
+            total_nats += mx.sum(loss_flat * mask).item()
+            total_bytes += int(mx.sum(nbytes).item())
+            mx.clear_cache()
 
     if total_bytes == 0:
         return float("inf")

--- a/train.py
+++ b/train.py
@@ -182,15 +182,19 @@ class GPT(nn.Module):
         return window_sizes
 
     def _get_masks(self, seq_len):
+        # Build masks in the model's dtype (bfloat16). scaled_dot_product_attention
+        # requires the mask to promote to the q/k/v dtype; now that the residual
+        # stream stays bf16 (issue #3), a float32 mask no longer promotes.
+        dtype = self.wte.weight.dtype
         unique_windows = set(self.window_sizes)
         for window_size in unique_windows:
-            key = (seq_len, window_size)
+            key = (seq_len, window_size, dtype)
             if key not in self._mask_cache:
                 if window_size >= seq_len:
-                    self._mask_cache[key] = create_additive_causal_mask(seq_len)
+                    self._mask_cache[key] = create_additive_causal_mask(seq_len, dtype=dtype)
                 else:
-                    self._mask_cache[key] = create_sliding_window_mask(seq_len, window_size)
-        return [self._mask_cache[(seq_len, window_size)] for window_size in self.window_sizes]
+                    self._mask_cache[key] = create_sliding_window_mask(seq_len, window_size, dtype=dtype)
+        return [self._mask_cache[(seq_len, window_size, dtype)] for window_size in self.window_sizes]
 
     def __call__(self, idx, targets=None, reduction="mean"):
         _, seq_len = idx.shape
@@ -200,7 +204,11 @@ class GPT(nn.Module):
         x = norm(x)
         x0 = x
         for i, block in enumerate(self.blocks):
-            x = self.resid_lambdas[i] * x + self.x0_lambdas[i] * x0
+            # Cast the fp32 scalars to the hidden-state dtype so the residual
+            # stream stays bfloat16. Without this, float32 * bfloat16 promotes
+            # to float32 and the whole network silently runs in fp32 after the
+            # first block, defeating the bf16 init (issue #3).
+            x = self.resid_lambdas[i].astype(x.dtype) * x + self.x0_lambdas[i].astype(x.dtype) * x0
             ve = self.value_embeds[str(i)](idx) if str(i) in self.value_embeds else None
             x = block(x, ve, masks[i])
         x = norm(x)


### PR DESCRIPTION
Two small, independent fixes for open issues.

### #2 — Out of Metal memory on 24GB Macs
`evaluate_bpb` ran the whole eval batch through the model in one forward, materializing a `(batch, seq, vocab)` float32 logits tensor. At defaults that's `256 × 2048 × 8192 × 4 = 16 GiB` in a single buffer — over the 14.3 GB max Metal buffer on a 24GB Air, exactly the number in the traceback.

Fix: split each eval batch along the batch axis so no single forward exceeds a 2 GiB logits budget (→ 32 rows/forward at defaults, peak 16 GiB → 2 GiB). BPB is a plain sum over tokens, so the metric is **numerically identical** regardless of batch size (verified: chunked vs full sums match to float precision). The cap is derived from `MAX_SEQ_LEN`/`VOCAB_SIZE`, so it adapts if those change.

### #3 — bf16 → fp32 upcast in residual mix
`resid_lambdas`/`x0_lambdas` are `float32` scalars, so `lambda * x` promoted the bf16 hidden state to `float32`, and the whole network silently ran in fp32 after the first block — defeating the bf16 init and inflating activation memory (which also feeds #2).

Fix: cast the scalars to `x.dtype` at use so the residual stream stays bf16. This exposed a latent coupling — the attention masks were fp32 (only worked because the stream was accidentally fp32), so `_get_masks` now builds masks in the model dtype, since `scaled_dot_product_attention` requires the mask to promote to the (now bf16) q/k/v dtype.

**Note:** #3 changes training numerics (bf16 is faster / lower memory but will shift val_bpb slightly). Verified it trains end-to-end: loss descends smoothly 9.01 → 7.46 over 60 steps, no NaN/inf, ~130K tok/sec. Worth a before/after eval run before relying on the new baseline.

Fixes #2, #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)