### PR TITLE
Add rigor.py: significance-gated keep/discard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ run.log
 surfaces.txt
 surface-verify-prompt.md
 build-2-closeout.md
+
+# rigor.py runtime state
+rigor_ledger.jsonl

--- a/README.md
+++ b/README.md
@@ -58,6 +58,28 @@ Longer overnight runs on the working MLX port pushed much further. The long Mac 
 
 The Mac Mini result matters because it did not just rediscover the same exact recipe. On smaller Apple Silicon hardware, the strongest changes leaned toward more aggressive step-efficiency wins. Later transfer tests showed some of those Mac Mini findings did not carry cleanly onto the Max baseline, which is exactly the kind of hardware-specific behavior this loop is useful for uncovering.
 
+## Rigorous keep/discard (optional)
+
+A single 5-minute run is noisy — re-running the *same* `train.py` moves `val_bpb`
+by ~0.03. Deciding keep/discard on one run below that threshold just chases
+noise, and since the loop only keeps a run that dips below the running best, the
+recorded curve is an optimistic running-minimum that regresses on honest re-eval.
+
+`rigor.py` gates the decision instead of eyeballing a single delta: it runs a few
+seeds and keeps a change only if it beats the current best with high confidence
+(bootstrap), fails a clear loser fast after one run, and never re-scores an
+identical `train.py`.
+
+```
+uv run rigor.py run "halve the batch size"   # score train.py vs best (3 seeds)
+uv run rigor.py run "..." --seeds 5 --confidence 0.9
+uv run rigor.py best                          # current best
+uv run rigor.py log                           # every scored config
+```
+
+It never edits `train.py`, touches git, or changes `evaluate_bpb` — it only
+decides, and writes samples to `rigor_ledger.jsonl`.
+
 ## Differences from upstream
 
 - **MLX instead of PyTorch/CUDA.** Native Apple Silicon training with unified memory.

--- a/rigor.py
+++ b/rigor.py
@@ -1,0 +1,151 @@
+"""
+rigor.py — significance-gated keep/discard for the autoresearch loop.
+
+A single training run is noisy: re-running the *same* train.py moves val_bpb by
+~0.03 here (nondeterministic GPU reductions, even with the seed pinned). Many
+changes the loop accepts improve by less than that, so it chases noise. And
+because it only keeps a run that dips below the running best and never re-checks,
+the recorded curve is an optimistic running-minimum that regresses on honest
+re-evaluation.
+
+This replaces "run once, eyeball the delta" with "run a few seeds, keep only if
+the change is better with high confidence." It also remembers every config it
+scored (hash of train.py), so an identical proposal is never re-run.
+
+    uv run rigor.py run "halve the batch size"        # score train.py vs best
+    uv run rigor.py run "..." --seeds 5 --confidence 0.9
+    uv run rigor.py best                              # current best
+    uv run rigor.py log                              # every scored config
+
+Samples and decisions land in rigor_ledger.jsonl. Nothing here edits train.py,
+touches git, or changes evaluate_bpb — it only decides.
+"""
+
+import argparse
+import hashlib
+import json
+import random
+import re
+import statistics
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+TRAIN = ROOT / "train.py"
+LEDGER = ROOT / "rigor_ledger.jsonl"
+TRAIN_CMD = ["uv", "run", "train.py"]
+VAL_RE = re.compile(r"^val_bpb:\s+([\d.]+)", re.M)
+
+
+def train_hash():
+    return hashlib.sha1(TRAIN.read_bytes()).hexdigest()[:7]
+
+
+def run_once():
+    """Run one training run, echo it live, return final val_bpb (None on crash)."""
+    proc = subprocess.Popen(TRAIN_CMD, cwd=ROOT, text=True,
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    out = []
+    for line in proc.stdout:
+        sys.stdout.write(line)
+        out.append(line)
+    proc.wait()
+    m = VAL_RE.search("".join(out))
+    return float(m.group(1)) if proc.returncode == 0 and m else None
+
+
+def load_ledger():
+    if not LEDGER.exists():
+        return []
+    return [json.loads(x) for x in LEDGER.read_text().splitlines() if x.strip()]
+
+
+def record(h, desc, samples, status, p):
+    entry = {"hash": h, "desc": desc, "samples": samples,
+             "mean": statistics.mean(samples) if samples else 0.0,
+             "std": statistics.pstdev(samples) if len(samples) > 1 else 0.0,
+             "status": status, "p_better": round(p, 4)}
+    with LEDGER.open("a") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def best_entry(ledger):
+    keeps = [e for e in ledger if e["status"] == "keep"]
+    return min(keeps, key=lambda e: e["mean"], default=None)
+
+
+def prob_improvement(best, cand, trials=20000):
+    """Bootstrap P(mean(cand) < mean(best)) — fraction of resamples the candidate wins."""
+    rng = random.Random(1234)  # fixed so a verdict is reproducible
+    nb, nc = len(best), len(cand)
+    wins = 0
+    for _ in range(trials):
+        b = sum(best[rng.randrange(nb)] for _ in range(nb)) / nb
+        c = sum(cand[rng.randrange(nc)] for _ in range(nc)) / nc
+        wins += c < b
+    return wins / trials
+
+
+def score(desc, seeds, confidence):
+    ledger = load_ledger()
+    h = train_hash()
+    prior = next((e for e in ledger if e["hash"] == h), None)
+    if prior:
+        print(f"already scored {h}: {prior['status']} (mean {prior['mean']:.6f}) — {prior['desc']}")
+        print("skipping (never-repeat). change train.py to try something new.")
+        return
+
+    best = best_entry(ledger)
+    samples = []
+    for i in range(seeds):
+        v = run_once()
+        if v is None:
+            record(h, desc, samples, "crash", 0.0)
+            print(f"\nCRASH {h}: training did not finish — logged.")
+            return
+        samples.append(v)
+        print(f"  seed {i + 1}/{seeds}: val_bpb {v:.6f}")
+        if best and i == 0 and v >= best["mean"]:  # clear loser, don't spend more seeds
+            record(h, desc, samples, "discard", 0.0)
+            print(f"\nDISCARD {h}: first run {v:.6f} >= best mean {best['mean']:.6f}.")
+            return
+
+    if best is None:  # first config is the baseline
+        e = record(h, desc, samples, "keep", 1.0)
+        print(f"\nBASELINE {h}: {e['mean']:.6f} +/- {e['std']:.6f} ({seeds} seeds)")
+        return
+
+    p = prob_improvement(best["samples"], samples)
+    keep = p >= confidence
+    status = "keep" if keep else "discard"
+    e = record(h, desc, samples, status, p)
+    print(f"\n{status.upper()} {h}: mean {e['mean']:.6f} vs best {best['mean']:.6f} "
+          f"(delta {e['mean'] - best['mean']:+.6f}), P(better)={p:.2f}, need >={confidence:.2f}")
+    print(f"tsv: {h}\t{e['mean']:.6f}\t-\t{status}\t{desc}")
+
+
+def main():
+    ap = argparse.ArgumentParser(description="significance-gated keep/discard for the autoresearch loop")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    r = sub.add_parser("run", help="score the current train.py against the best")
+    r.add_argument("desc", help="short description of the change")
+    r.add_argument("--seeds", type=int, default=3, help="training runs to average (default 3)")
+    r.add_argument("--confidence", type=float, default=0.95, help="P(better) needed to keep (default 0.95)")
+    sub.add_parser("best", help="show the current best config")
+    sub.add_parser("log", help="show every scored config")
+    a = ap.parse_args()
+
+    if a.cmd == "run":
+        score(a.desc, a.seeds, a.confidence)
+    elif a.cmd == "best":
+        b = best_entry(load_ledger())
+        print(f"best {b['hash']}: {b['mean']:.6f} +/- {b['std']:.6f} — {b['desc']}" if b else "no baseline yet.")
+    elif a.cmd == "log":
+        for e in load_ledger():
+            print(f"{e['hash']}  {e['mean']:.6f}  {e['status']:8s}  p={e['p_better']:.2f}  {e['desc']}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### The problem, from this repo's own data
A single 5-minute run is noisy — re-running the *same* `train.py` moves `val_bpb` by ~**0.03** (the post-loop verification run in the build notes: 2.564 vs the logged 2.534). But many accepted changes improve by far less than that — a long tail of `keep` decisions have deltas between 0.0002 and 0.009. Deciding keep/discard on one run below noise just chases noise. And because the loop only keeps a run that dips below the running best and never re-checks, the recorded curve is a **downward-biased running-minimum** that regresses on honest re-evaluation.

### What this adds
`rigor.py` — a small, dependency-free (stdlib only) tool that gates the decision instead of eyeballing one delta:

- **Significance gate** — runs a few seeds and keeps a change only if it beats the current best with high confidence (bootstrap resample; default P ≥ 0.95).
- **Fail-fast** — discards a clear loser after a single run (no wasted seeds).
- **Never-repeat** — hashes `train.py`; an identical proposal is reported from the ledger, not re-run.

```
uv run rigor.py run "halve the batch size"     # score train.py vs best (3 seeds)
uv run rigor.py run "..." --seeds 5 --confidence 0.9
uv run rigor.py best
uv run rigor.py log
```

It never edits `train.py`, touches git, or changes `evaluate_bpb` — it only decides, and writes samples to `rigor_ledger.jsonl` (gitignored).

### Behavior (verified with stubbed runs)
| change | mean vs best | decision | why |
|---|---|---|---|
| −0.100 | 1.302 vs 1.402 | **keep** | P(better)=1.00 |
| −0.002 | 1.2997 vs 1.3017 | **discard** | P(better)=0.81 — inside the noise, even though the number is lower |
| +0.038 (1st seed) | — | **discard** | fails fast after one run |
| identical `train.py` | — | **skip** | already scored |

The second row is the case the current loop gets wrong: a lower number that isn't real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)